### PR TITLE
Remove Biomes! Core from the incompatibleWith list

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -13,7 +13,6 @@
 	<incompatibleWith>
 		<li>wemd.realisticdarkness</li>
 		<li>wemd.realisticdarknesslight</li>
-		<li>biomesteam.biomescore</li>
 	</incompatibleWith>
 	<modDependencies>
 		<li>


### PR DESCRIPTION
Biomes! Core recently removed its bundled copy of Moonlight, so now it can be marked as compatible.

For reference, it was removed in these commits:

https://github.com/biomes-team/BiomesCore/commit/added2158d2645ee8812d1d54eb007c644cff6cf
https://github.com/biomes-team/BiomesCore/commit/6efd44c71ad36a7b5a2c7bd148f8bc547e2af330